### PR TITLE
feat: support providing a custom stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ spin.stop();
 | text | string | console text | empty string |
 | timeout | number | the time of changing to next frame | 100(ms) |
 | spinners | string[] | frame list | `['⠋', '⠙', '⠹', '⠼', '⠴', '⠦', '⠧', '⠏']` |
+| stream | WritableStream | the stream to send the output to | stdout |
 
 
 [MIT LICENSE](./LICENSE)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,14 @@ export default class LightSpinner {
   private spinners;
   private message;
   private timeHandler;
+  private stream: NodeJS.WritableStream;
   private isWin = platform() === 'win32';
   constructor(config?: IOption) {
-    const { spinners, text, timeout } = config || {};
+    const { spinners, text, timeout, stream } = config || {};
     this.spinners = spinners || this.isWin ? ['-', '\\', '/'] : ['⠋', '⠙', '⠹', '⠼', '⠴', '⠦', '⠧', '⠏'];
     this.timeout = timeout || 100;
     this.text = text || '';
+    this.stream = stream || process.stdout;
   }
 
   public start() {
@@ -33,13 +35,13 @@ export default class LightSpinner {
     }
     const clearChar = '\u001b[2K'; // use 'CSI n K' erase in line : \x01[nK
     const moveCursor = `\u001b[${Buffer.byteLength(this.message)}D`; // use 'CSI n D' cursor back : \x01[nD
-    process.stdout.write(clearChar);
-    process.stdout.write(moveCursor);
+    this.stream.write(clearChar);
+    this.stream.write(moveCursor);
   }
 
   private output(message: string) {
     this.message = message;
-    process.stdout.write(message);
+    this.stream.write(message);
   }
 
   private doing() {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -2,4 +2,5 @@ export interface IOption {
   spinners?: string[];
   text?: string;
   timeout?: number;
+  stream?: NodeJS.WritableStream;
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -27,4 +27,35 @@ describe('/test/index.test.ts', () => {
     clearTimeout(consoleTimeout);
     assert(true);
   });
+
+  it('uses stdout by default', () => {
+    const stdoutWriteSpy = jest.spyOn(process.stdout, 'write');
+
+    const spin = new Spin({
+      text: 'this will go to stdout'
+    });
+
+    spin.start();
+    spin.stop();
+
+    expect(stdoutWriteSpy).toBeCalledWith(expect.stringContaining('this will go to stdout'));
+  });
+
+  describe('when providing a custom stream', () => {
+    it('uses that stream', () => {
+      const stderrWriteSpy = jest.spyOn(process.stderr, 'write');
+      const stdoutWriteSpy = jest.spyOn(process.stdout, 'write');
+
+      const spin = new Spin({
+        text: 'this will go to stderr',
+        stream: process.stderr
+      });
+
+      spin.start();
+      spin.stop();
+
+      expect(stderrWriteSpy).toBeCalledWith(expect.stringContaining('this will go to stderr'));
+      expect(stdoutWriteSpy).not.toBeCalledWith(expect.stringContaining('this will go to stderr'));
+    });
+  });
 });


### PR DESCRIPTION
It's more common that cosmetic output like spinners is sent to `stderr`, but currently this spinner is hard-coded to go to `stdout`.

Ideally I'd recommend changing the default stream to be `stderr` but that's arguably a breaking change so for now have left it as `stdout`.